### PR TITLE
Fix Storage Schema to lessen load on machines.

### DIFF
--- a/files/var/lib/graphite/conf/storage-schemas.conf
+++ b/files/var/lib/graphite/conf/storage-schemas.conf
@@ -4,4 +4,4 @@ retentions = 1m:90d
 
 [default]
 pattern = .*
-retentions = 1m:1d,10m:7d,1h:45d,1d:3y
+retentions = 1m:1d,10m:14d


### PR DESCRIPTION
 4 rollups means you generate 4 reads for every write or every metric. It makes a HUGE difference.
